### PR TITLE
Windows can now be appended to or replaced

### DIFF
--- a/lib/gardenbed/key_manager.rb
+++ b/lib/gardenbed/key_manager.rb
@@ -14,7 +14,7 @@ module Gardenbed
     end
 
     def character_for_keypress(keypress)
-      Gardenbed.instance.logger.info("Pressed key #{keypress}")
+      #Gardenbed.instance.logger.info("Pressed key #{keypress}")
       if keypress == 27
         @current_modifier_key = :alt
         return

--- a/lib/gardenbed/screen.rb
+++ b/lib/gardenbed/screen.rb
@@ -56,9 +56,9 @@ module Gardenbed
         loop do
           return if @active_window.nil?
 
-          key = @active_window.wait_for_key_char
+          key = @tracking_window.wait_for_key_char
           character = Gardenbed.instance.key_manager.character_for_keypress(key) unless key.nil?
-          @active_window.update_string_value += character unless character.nil?
+          @active_window.update_string_value(character) unless character.nil?
         end
       end
     end

--- a/lib/gardenbed/window.rb
+++ b/lib/gardenbed/window.rb
@@ -5,16 +5,34 @@ require 'erb'
 module Gardenbed
   # Manager for a Curses Window
   # Make sure you've initialized a Screen first, or this will fail in fun ways
+  #
+  # There's two ways to manage this content
+  # It can either be a string (such as from a keyboard) or a template with a backing data set
+  # For string call `string_value=` to write to the content. This content is always appended, so that
+  # if you're typing it's always adding
+  #
+  # The second way to set this up is by setting `template=` which takes in an erb string
+  # You then update the variables in the template by setting `data_hash=`, this will redraw the template
+  # and update the content.
+  #
+  # Internally this is all done using the `@update_queue` `Queue` object, so if multiple changes are
+  # written at any given time they're all run (more or less, there's going to be optimizations so that
+  # not everything is run if eventually one of the changes overwrites the previous ones)
   class Window
     SIGNALS = { run: 0, halt: 1 }.freeze
+
+    # This is a struct designed for the `@update_queue`
+    # +content+: A string containing the content to add
+    # +update_type+: An UpdateQueueObject::UPDATE_TYPES, for now `:append` or `:replace`
+    UpdateQueueObject = Struct.new(:content, :update_type) do
+      UPDATE_TYPES = { append: 0, replace: 1 }.freeze
+    end
 
     attr_reader :border_vertical, :border_horizontal
     attr_reader :cursor_x, :cursor_y
 
     attr_reader :string_value
     attr_reader :template
-
-    attr_accessor :update_string_value
 
     def initialize(height, width, x_pos, y_pos)
       @window = Curses::Window.new height, width, x_pos, y_pos
@@ -29,16 +47,32 @@ module Gardenbed
       @data_hash = {}
       @update_string_value = ''
 
+      # Sets up the queue for updates
+      @update_queue = Queue.new
+
       redraw
     end
 
     def update
       # If the update string is empty or equal to what we already have in the window
-      return unless should_update_window?
+      # return unless should_update_window?
 
       # Update the string values and redraw the string
-      self.string_value += @update_string_value
-      @update_string_value = ''
+      # Run through the current `@update_queue` and draw it all out
+      # if it's a :replace, then replace, if it's an :append, then append
+      until @update_queue.empty?
+        update_queue_object = @update_queue.pop
+
+        case update_queue_object.update_type
+        when UPDATE_TYPES[:append]
+          self.string_value += update_queue_object.content
+        when UPDATE_TYPES[:replace]
+          self.string_value = update_queue_object.content
+        else
+          raise 'Incorrect update type provided to update queue.'
+        end
+      end
+
       redraw
     end
 
@@ -53,7 +87,11 @@ module Gardenbed
 
     def update_data(data_hash)
       @data_hash.merge! data_hash
-      @update_string_value = compose_template
+      @update_queue << UpdateQueueObject.new(compose_template, UPDATE_TYPES[:replace])
+    end
+
+    def update_string_value(string)
+      @update_queue << UpdateQueueObject.new(string, UPDATE_TYPES[:append])
     end
 
     def border_vertical=(symbol)
@@ -124,11 +162,11 @@ module Gardenbed
     end
 
     def should_update_window?
-      return_value = true
-      return_value = false if @update_string_value&.empty?
-      return_value = false if @update_string_value == @string_value
+      # return_value = true
+      # return_value = false if @update_string_value&.empty?
+      # return_value = false if @update_string_value == @string_value
 
-      return_value
+      !@update_queue.empty?
     end
   end
 end


### PR DESCRIPTION
**Description**
We either want windows to replace their content (for instance if you're
running the thing off a template and you update the date), or we want to
append, such as if we're typing. This adds the following:

- Switch drawing on a window to a queue system so that changes can be
  queued up and run sequentially on every clock tick.
- The queue can take in a `UpdateQueueObject` with the content as a
  string and the type as a `UPDATE_TYPES`
- Switched it up so that the tracking window is used to manage all
  keypresses, which was what it was supposed to do anyways.

🚨**Testing:**
Too early to do right now

**Effects**
Closes #3
