### PR TITLE
Move cursor around properly when adding borders

### DIFF
--- a/lib/gardenbed/screen.rb
+++ b/lib/gardenbed/screen.rb
@@ -67,6 +67,8 @@ module Gardenbed
       Thread.new do
         loop do
           @windows.each(&:update)
+          @active_window&.reset_cursor_point
+
           sleep CLOCKSPEED
         end
       end


### PR DESCRIPTION
**Description**
Allow the cursor to better handle its position relative to any borders
given. Also adds a `Point` struct for `Window` to make it a bit easier
to figure out where you are.

🚨**Testing:**
Start up a window and make sure that the typing begins in the right
place given a border

**Effects**
Closes #14
